### PR TITLE
Bug travis error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ matrix:
     python: 2.7
     env: PYTHON_VERSION=2.7
   - os: linux
-    python: 3.4
-    env: PYTHON_VERSION=3.4 # triggers source build of pandas; drop?
-  - os: linux
     python: 3.5
     env: PYTHON_VERSION=3.5
   - os: linux                                                                   
@@ -19,10 +16,6 @@ matrix:
     language: generic
     env:
     - PYTHON_VERSION=2.7
-  - os: osx
-    language: generic
-    env:
-    - PYTHON_VERSION=3.4 # triggers source build of pandas; drop?
   - os: osx
     language: generic
     env:
@@ -50,13 +43,8 @@ install:
   - conda create --yes -n py_stringsimjoin_test_env python=$PYTHON_VERSION
   - source activate py_stringsimjoin_test_env
   - python --version
-  
-  # Why does py_stringsimjoin have a dependency on gcc but py_stringmatching doesn't?
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then conda install --yes gcc; fi                              
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then conda install --yes gcc; fi
   - which gcc
-  
-  # Python package dependencies; put in requirements.txt?
-  # Or get rid of these and rely on install_requires
   - pip install pandas joblib six nose Cython pyprind==2.9.8 py_stringmatching coveralls
   - python setup.py build_ext --inplace
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,22 +33,29 @@ compiler:
     - gcc
 
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget http://repo.continuum.io/miniconda/Miniconda2-4.0.5-Linux-x86_64.sh -O miniconda.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget https://repo.continuum.io/miniconda/Miniconda2-4.0.5-MacOSX-x86_64.sh -O miniconda.sh; fi
+  - if [ "$TRAVIS_OS_NAME" == linux ]; then MINICONDAVERSION="Linux"; else MINICONDAVERSION="MacOSX"; fi
+  - if [ "$PYTHON_VERSION" == "2.7" ]; then wget http://repo.continuum.io/miniconda/Miniconda2-latest-$MINICONDAVERSION-x86_64.sh -O miniconda.sh; fi
+  - if [ "$PYTHON_VERSION" != "2.7" ]; then wget http://repo.continuum.io/miniconda/Miniconda3-latest-$MINICONDAVERSION-x86_64.sh -O miniconda.sh; fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
-#  - conda update --yes conda
 
 install:
-  - conda install --yes python=$PYTHON_VERSION pandas joblib six nose Cython
+  - conda create --yes -n py_stringsimjoin_test_env python=$PYTHON_VERSION
+  - source activate py_stringsimjoin_test_env
+  - python --version
+  
+  # Why does py_stringsimjoin have a dependency on gcc but py_stringmatching doesn't?
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then conda install --yes gcc; fi                              
   - which gcc
-  - pip install pyprind==2.9.8 py_stringmatching coveralls
-  - python --version
+  
+  # Python package dependencies; put in requirements.txt?
+  # Or get rid of these and rely on install_requires
+  - pip install pandas joblib six nose Cython pyprind==2.9.8 py_stringmatching coveralls
   - python setup.py build_ext --inplace
 
 script:
   - coverage run -m nose
+  - uname -a
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,16 @@ matrix:
     env: PYTHON_VERSION=2.7
   - os: linux
     python: 3.4
-    env: PYTHON_VERSION=3.4
+    env: PYTHON_VERSION=3.4 # triggers source build of pandas; drop?
   - os: linux
     python: 3.5
     env: PYTHON_VERSION=3.5
   - os: linux                                                                   
     python: 3.6                                                                 
     env: PYTHON_VERSION=3.6     
+  - os: linux
+    python: 3.7
+    env: PYTHON_VERSION=3.7
   - os: osx
     language: generic
     env:
@@ -19,7 +22,7 @@ matrix:
   - os: osx
     language: generic
     env:
-    - PYTHON_VERSION=3.4
+    - PYTHON_VERSION=3.4 # triggers source build of pandas; drop?
   - os: osx
     language: generic
     env:
@@ -28,6 +31,10 @@ matrix:
     language: generic                                                           
     env:                                                                        
     - PYTHON_VERSION=3.6  
+  - os: osx
+    language: generic
+    env:
+    - PYTHON_VERSION=3.7
 
 compiler:
     - gcc


### PR DESCRIPTION
Updated travis.yml file to reflect changes in supported python versions for this package. Changes in python version support:

- python 3.3 and python 3.4 are no longer supported. This is due to the age of these versions as well as changes in support from other packages we rely on (specifically Numpy no longer supports 3.3 in its newest versions and pandas has dropped testing for 3.4).
- python 2.7, 3.5, 3.6 support is unchanged
- python 3.7 is now tested in travis