### PR TITLE
Update dataframe ix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ install:
   - conda create --yes -n py_stringsimjoin_test_env python=$PYTHON_VERSION
   - source activate py_stringsimjoin_test_env
   - python --version
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then conda install --yes gcc; fi
   - which gcc
   - pip install --upgrade pip
   - pip install pandas joblib six nose Cython pyprind==2.9.8 py_stringmatching coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
   - python --version
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then conda install --yes gcc; fi
   - which gcc
+  - pip install --upgrade pip
   - pip install pandas joblib six nose Cython pyprind==2.9.8 py_stringmatching coveralls
   - python setup.py build_ext --inplace
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
   - python --version
   - which gcc
   - pip install --upgrade pip
+  - pip install "numpy<1.19"
   - pip install pandas joblib six nose Cython pyprind==2.9.8 py_stringmatching coveralls
   - python setup.py build_ext --inplace
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ install:
   - python -m pip install --upgrade pip
 
   # Install the build and runtime dependencies of the project.
+  - pip install "numpy<1.19"
   - pip install setuptools pandas six joblib py_stringmatching nose cython
   - pip install pyprind==2.9.8
 

--- a/py_stringsimjoin/tests/test_converter_utils.py
+++ b/py_stringsimjoin/tests/test_converter_utils.py
@@ -71,7 +71,7 @@ class DataframeColumnToStrTestCases(unittest.TestCase):
             if pd.isnull(row['float_col_with_int_val']): 
                 continue
             assert_equal(str(int(row['float_col_with_int_val'])),
-                         out_df.ix[idx]['float_col_with_int_val'])
+                         out_df.loc[idx]['float_col_with_int_val'])
 
     def test_str_col_with_inplace(self):                                      
         assert_equal(self.dataframe['str_col'].dtype, object)                  
@@ -214,7 +214,7 @@ class SeriesToStrTestCases(unittest.TestCase):
         for idx, val in self.float_col_with_int_val.iteritems():                              
             if pd.isnull(val):                        
                 continue                                                        
-            assert_equal(str(int(val)), out_series.ix[idx])              
+            assert_equal(str(int(val)), out_series.loc[idx])              
                                                                                 
     def test_str_col_with_inplace(self):                                        
         assert_equal(self.str_col.dtype, object)                   


### PR DESCRIPTION
Similar to [this issue](https://github.com/anhaidgroup/py_entitymatching/issues/134), Pandas 1.0.0 dropped the .ix indexer in favor of .loc and .iloc. This pull request updates the usage of .ix to be compatible with recent versions of Pandas, and provides some minor changes to the CI environment to reflect updates to Miniconda and to support Python 3.5.