### PR TITLE
Update usage of pandas.np to reference numpy directly.

### DIFF
--- a/py_stringsimjoin/matcher/apply_matcher.py
+++ b/py_stringsimjoin/matcher/apply_matcher.py
@@ -4,6 +4,7 @@ import types
 
 from joblib import delayed, Parallel
 from six.moves import copyreg
+import numpy as np
 import pandas as pd
 import pyprind
 
@@ -299,7 +300,7 @@ def _apply_matcher_split(candset,
         if pd.isnull(l_apply_col_value) or pd.isnull(r_apply_col_value):
             if allow_missing:
                 allow_pair = True
-                sim_score = pd.np.NaN
+                sim_score = np.NaN
             else:
                 continue   
         else:

--- a/py_stringsimjoin/tests/test_converter_utils.py
+++ b/py_stringsimjoin/tests/test_converter_utils.py
@@ -3,6 +3,7 @@ import string
 import unittest
 
 from nose.tools import assert_equal, assert_list_equal, raises
+import numpy as np
 import pandas as pd
 
 from py_stringsimjoin.utils.converter import dataframe_column_to_str, \
@@ -11,16 +12,16 @@ from py_stringsimjoin.utils.converter import dataframe_column_to_str, \
 
 class DataframeColumnToStrTestCases(unittest.TestCase):
     def setUp(self):
-        float_col = pd.Series(pd.np.random.randn(10)).append(
-            pd.Series([pd.np.NaN for _ in range(10)], index=range(10, 20)))
+        float_col = pd.Series(np.random.randn(10)).append(
+            pd.Series([np.NaN for _ in range(10)], index=range(10, 20)))
         float_col_with_int_val = pd.Series(
-                                     pd.np.random.randint(1, 100, 10)).append(          
-            pd.Series([pd.np.NaN for _ in range(10)], index=range(10, 20)))        
+                                     np.random.randint(1, 100, 10)).append(          
+            pd.Series([np.NaN for _ in range(10)], index=range(10, 20)))        
         str_col = pd.Series([random.choice(string.ascii_lowercase) 
                       for _ in range(10)]).append(
-            pd.Series([pd.np.NaN for _ in range(10)], index=range(10, 20)))
-        int_col = pd.Series(pd.np.random.randint(1, 100, 20))                           
-        nan_col = pd.Series([pd.np.NaN for _ in range(20)])                
+            pd.Series([np.NaN for _ in range(10)], index=range(10, 20)))
+        int_col = pd.Series(np.random.randint(1, 100, 20))                           
+        nan_col = pd.Series([np.NaN for _ in range(20)])                
 
         self.dataframe = pd.DataFrame({'float_col': float_col,
                                'float_col_with_int_val': float_col_with_int_val,
@@ -166,16 +167,16 @@ class DataframeColumnToStrTestCases(unittest.TestCase):
 
 class SeriesToStrTestCases(unittest.TestCase):                         
     def setUp(self):                                                            
-        self.float_col = pd.Series(pd.np.random.randn(10)).append(                   
-            pd.Series([pd.np.NaN for _ in range(10)], index=range(10, 20)))     
+        self.float_col = pd.Series(np.random.randn(10)).append(                   
+            pd.Series([np.NaN for _ in range(10)], index=range(10, 20)))     
         self.float_col_with_int_val = pd.Series(                                     
-                                     pd.np.random.randint(1, 100, 10)).append(  
-            pd.Series([pd.np.NaN for _ in range(10)], index=range(10, 20)))     
+                                     np.random.randint(1, 100, 10)).append(  
+            pd.Series([np.NaN for _ in range(10)], index=range(10, 20)))     
         self.str_col = pd.Series([random.choice(string.ascii_lowercase)              
                       for _ in range(10)]).append(                              
-            pd.Series([pd.np.NaN for _ in range(10)], index=range(10, 20)))     
-        self.int_col = pd.Series(pd.np.random.randint(1, 100, 20))                   
-        self.nan_col = pd.Series([pd.np.NaN for _ in range(20)])
+            pd.Series([np.NaN for _ in range(10)], index=range(10, 20)))     
+        self.int_col = pd.Series(np.random.randint(1, 100, 20))                   
+        self.nan_col = pd.Series([np.NaN for _ in range(20)])
                                    
     def test_str_col(self):                                                     
         assert_equal(self.str_col.dtype, object)                   

--- a/py_stringsimjoin/tests/test_overlap_filter.py
+++ b/py_stringsimjoin/tests/test_overlap_filter.py
@@ -3,6 +3,7 @@ import unittest
 from nose.tools import assert_equal, assert_list_equal, nottest, raises
 from py_stringmatching.tokenizer.delimiter_tokenizer import DelimiterTokenizer
 from py_stringmatching.tokenizer.qgram_tokenizer import QgramTokenizer
+import numpy as np
 import pandas as pd
 
 from py_stringsimjoin.filter.overlap_filter import OverlapFilter
@@ -36,11 +37,11 @@ class FilterPairTestCases(unittest.TestCase):
                               self.dlm, 1, '>=', True, False)
 
     def test_overlap_pass_missing_right(self):
-        self.test_filter_pair('fg ty', pd.np.NaN,
+        self.test_filter_pair('fg ty', np.NaN,
                               self.dlm, 1, '>=', True, False)
 
     def test_overlap_pass_missing_both(self):
-        self.test_filter_pair(None, pd.np.NaN,
+        self.test_filter_pair(None, np.NaN,
                               self.dlm, 1, '>=', True, False)
 
     # tests for empty string input
@@ -77,7 +78,7 @@ class FilterTablesTestCases(unittest.TestCase):
                                {'id': 3, 'attr':'xy pl ou'},
                                {'id': 4, 'attr':'aa'},
                                {'id': 5, 'attr':'fg cd aa ef'},
-                               {'id': 6, 'attr':pd.np.NaN}])
+                               {'id': 6, 'attr':np.NaN}])
         self.empty_table = pd.DataFrame(columns=['id', 'attr'])
         self.default_l_out_prefix = 'l_'
         self.default_r_out_prefix = 'r_'
@@ -226,7 +227,7 @@ class FilterCandsetTestCases(unittest.TestCase):
                                {'l_id': 3, 'l_attr':'ab'},
                                {'l_id': 4, 'l_attr':'ll oo pp'},
                                {'l_id': 5, 'l_attr':'xy xx zz fg'},
-                               {'l_id': 6, 'l_attr':pd.np.NaN}])
+                               {'l_id': 6, 'l_attr':np.NaN}])
         self.B = pd.DataFrame([{'r_id': 1, 'r_attr':'mn'},
                                {'r_id': 2, 'r_attr':'he ll'},
                                {'r_id': 3, 'r_attr':'xy pl ou'},

--- a/py_stringsimjoin/tests/test_position_filter.py
+++ b/py_stringsimjoin/tests/test_position_filter.py
@@ -3,6 +3,7 @@ import unittest
 from nose.tools import assert_equal, assert_list_equal, nottest, raises
 from py_stringmatching.tokenizer.delimiter_tokenizer import DelimiterTokenizer
 from py_stringmatching.tokenizer.qgram_tokenizer import QgramTokenizer
+import numpy as np
 import pandas as pd
 
 from py_stringsimjoin.filter.position_filter import PositionFilter
@@ -87,11 +88,11 @@ class FilterPairTestCases(unittest.TestCase):
                               self.dlm, 'DICE', 0.8, False, True, False)
 
     def test_pos_filter_pass_missing_right(self):
-        self.test_filter_pair('fg ty', pd.np.NaN,
+        self.test_filter_pair('fg ty', np.NaN,
                               self.dlm, 'DICE', 0.8, False, True, False)
 
     def test_pos_filter_pass_missing_both(self):
-        self.test_filter_pair(None, pd.np.NaN,
+        self.test_filter_pair(None, np.NaN,
                               self.dlm, 'DICE', 0.8, False, True, False)
 
     # tests for empty string input
@@ -129,7 +130,7 @@ class FilterTablesTestCases(unittest.TestCase):
                                {'id': 3, 'attr':'ab'},
                                {'id': 4, 'attr':'ll oo he'},
                                {'id': 5, 'attr':'xy xx zz fg'},
-                               {'id': 6, 'attr':pd.np.NaN},
+                               {'id': 6, 'attr':np.NaN},
                                {'id': 7, 'attr':''}])
         self.B = pd.DataFrame([{'id': 1, 'attr':'zz fg xx'},
                                {'id': 2, 'attr':'he ll'},
@@ -197,12 +198,12 @@ class FilterTablesTestCases(unittest.TestCase):
                           {'l_id': 2, 'l_attr':'200'},
                           {'l_id': 3, 'l_attr':'0'},
                           {'l_id': 4, 'l_attr':''},
-                          {'l_id': 5, 'l_attr':pd.np.NaN}])
+                          {'l_id': 5, 'l_attr':np.NaN}])
         B = pd.DataFrame([{'r_id': 1, 'r_attr':'200155'},
                           {'r_id': 2, 'r_attr':'190'},
                           {'r_id': 3, 'r_attr':'2010'},
                           {'r_id': 4, 'r_attr':''},
-                          {'r_id': 5, 'r_attr':pd.np.NaN},
+                          {'r_id': 5, 'r_attr':np.NaN},
                           {'r_id': 6, 'r_attr':'18950'}])
 
         qg2_tok = QgramTokenizer(2)
@@ -355,7 +356,7 @@ class FilterCandsetTestCases(unittest.TestCase):
                                {'l_id': 3, 'l_attr':'ab'},
                                {'l_id': 4, 'l_attr':'ll oo he'},
                                {'l_id': 5, 'l_attr':'xy xx zz fg'},
-                               {'l_id': 6, 'l_attr': pd.np.NaN}])
+                               {'l_id': 6, 'l_attr': np.NaN}])
         self.B = pd.DataFrame([{'r_id': 1, 'r_attr':'zz fg xx'},
                                {'r_id': 2, 'r_attr':'he ll'},
                                {'r_id': 3, 'r_attr':'xy pl ou'},

--- a/py_stringsimjoin/tests/test_prefix_filter.py
+++ b/py_stringsimjoin/tests/test_prefix_filter.py
@@ -3,6 +3,7 @@ import unittest
 from nose.tools import assert_equal, assert_list_equal, nottest, raises
 from py_stringmatching.tokenizer.delimiter_tokenizer import DelimiterTokenizer
 from py_stringmatching.tokenizer.qgram_tokenizer import QgramTokenizer
+import numpy as np
 import pandas as pd
 
 from py_stringsimjoin.filter.prefix_filter import PrefixFilter
@@ -87,11 +88,11 @@ class FilterPairTestCases(unittest.TestCase):
                               self.dlm, 'DICE', 0.8, False, True, False)
 
     def test_prefix_filter_pass_missing_right(self):
-        self.test_filter_pair('fg ty', pd.np.NaN,
+        self.test_filter_pair('fg ty', np.NaN,
                               self.dlm, 'DICE', 0.8, False, True, False)
 
     def test_prefix_filter_pass_missing_both(self):
-        self.test_filter_pair(None, pd.np.NaN,
+        self.test_filter_pair(None, np.NaN,
                               self.dlm, 'DICE', 0.8, False, True, False)
 
     # tests for empty string input
@@ -129,7 +130,7 @@ class FilterTablesTestCases(unittest.TestCase):
                                {'id': 3, 'attr':'ab'},
                                {'id': 4, 'attr':'ll oo he'},
                                {'id': 5, 'attr':'xy xx zz fg'},
-                               {'id': 6, 'attr':pd.np.NaN},
+                               {'id': 6, 'attr':np.NaN},
                                {'id': 7, 'attr':''}])
         self.B = pd.DataFrame([{'id': 1, 'attr':'zz fg xx'},
                                {'id': 2, 'attr':'he ll'},
@@ -197,12 +198,12 @@ class FilterTablesTestCases(unittest.TestCase):
                           {'l_id': 2, 'l_attr':'200'},
                           {'l_id': 3, 'l_attr':'0'},
                           {'l_id': 4, 'l_attr':''},
-                          {'l_id': 5, 'l_attr':pd.np.NaN}])
+                          {'l_id': 5, 'l_attr':np.NaN}])
         B = pd.DataFrame([{'r_id': 1, 'r_attr':'200155'},
                           {'r_id': 2, 'r_attr':'190'},
                           {'r_id': 3, 'r_attr':'2010'},
                           {'r_id': 4, 'r_attr':''},
-                          {'r_id': 5, 'r_attr':pd.np.NaN},
+                          {'r_id': 5, 'r_attr':np.NaN},
                           {'r_id': 6, 'r_attr':'18950'}])
 
         qg2_tok = QgramTokenizer(2)
@@ -357,7 +358,7 @@ class FilterCandsetTestCases(unittest.TestCase):
                                {'l_id': 3, 'l_attr':'ab'},
                                {'l_id': 4, 'l_attr':'ll oo he'},
                                {'l_id': 5, 'l_attr':'xy xx zz fg'},
-                               {'l_id': 6, 'l_attr': pd.np.NaN}])
+                               {'l_id': 6, 'l_attr': np.NaN}])
         self.B = pd.DataFrame([{'r_id': 1, 'r_attr':'zz fg xx'},
                                {'r_id': 2, 'r_attr':'he ll'},
                                {'r_id': 3, 'r_attr':'xz pl ou'},

--- a/py_stringsimjoin/tests/test_size_filter.py
+++ b/py_stringsimjoin/tests/test_size_filter.py
@@ -3,6 +3,7 @@ import unittest
 from nose.tools import assert_equal, assert_list_equal, nottest, raises
 from py_stringmatching.tokenizer.delimiter_tokenizer import DelimiterTokenizer
 from py_stringmatching.tokenizer.qgram_tokenizer import QgramTokenizer
+import numpy as np
 import pandas as pd
 
 from py_stringsimjoin.filter.size_filter import SizeFilter
@@ -91,11 +92,11 @@ class FilterPairTestCases(unittest.TestCase):
                               self.dlm, 'DICE', 0.8, False, True, False)
 
     def test_size_filter_pass_missing_right(self):
-        self.test_filter_pair('fg ty', pd.np.NaN,
+        self.test_filter_pair('fg ty', np.NaN,
                               self.dlm, 'DICE', 0.8, False, True, False)
 
     def test_size_filter_pass_missing_both(self):
-        self.test_filter_pair(None, pd.np.NaN,
+        self.test_filter_pair(None, np.NaN,
                               self.dlm, 'DICE', 0.8, False, True, False)
 
     # tests for empty string input
@@ -140,7 +141,7 @@ class FilterTablesTestCases(unittest.TestCase):
                                {'id': 3, 'attr':'xy pl ou'},
                                {'id': 4, 'attr':'aa'},
                                {'id': 5, 'attr':'fg cd aa ef'},
-                               {'id': 6, 'attr':pd.np.NaN},
+                               {'id': 6, 'attr':np.NaN},
                                {'id': 7, 'attr':' '}])
 
         self.empty_table = pd.DataFrame(columns=['id', 'attr'])
@@ -204,12 +205,12 @@ class FilterTablesTestCases(unittest.TestCase):
                           {'l_id': 2, 'l_attr':'200'},
                           {'l_id': 3, 'l_attr':'0'},
                           {'l_id': 4, 'l_attr':''},
-                          {'l_id': 5, 'l_attr':pd.np.NaN}])
+                          {'l_id': 5, 'l_attr':np.NaN}])
         B = pd.DataFrame([{'r_id': 1, 'r_attr':'200155'},
                           {'r_id': 2, 'r_attr':'19'},
                           {'r_id': 3, 'r_attr':'188'},
                           {'r_id': 4, 'r_attr':''},
-                          {'r_id': 5, 'r_attr':pd.np.NaN}])
+                          {'r_id': 5, 'r_attr':np.NaN}])
 
         qg2_tok = QgramTokenizer(2)
         expected_pairs = set(['1,1', '1,2', '1,3',
@@ -365,7 +366,7 @@ class FilterCandsetTestCases(unittest.TestCase):
                                {'l_id': 3, 'l_attr':'ab'},
                                {'l_id': 4, 'l_attr':'ll oo pp'},
                                {'l_id': 5, 'l_attr':'xy xx zz fg'},
-                               {'l_id': 6, 'l_attr': pd.np.NaN}])
+                               {'l_id': 6, 'l_attr': np.NaN}])
         self.B = pd.DataFrame([{'r_id': 1, 'r_attr':'mn'},
                                {'r_id': 2, 'r_attr':'he ll'},
                                {'r_id': 3, 'r_attr':'xy pl ou'},

--- a/py_stringsimjoin/tests/test_suffix_filter.py
+++ b/py_stringsimjoin/tests/test_suffix_filter.py
@@ -3,6 +3,7 @@ import unittest
 from nose.tools import assert_equal, assert_list_equal, nottest, raises
 from py_stringmatching.tokenizer.delimiter_tokenizer import DelimiterTokenizer
 from py_stringmatching.tokenizer.qgram_tokenizer import QgramTokenizer
+import numpy as np
 import pandas as pd
 
 from py_stringsimjoin.filter.suffix_filter import SuffixFilter
@@ -118,7 +119,7 @@ class FilterTablesTestCases(unittest.TestCase):
                                {'id': 3, 'attr':'ab'},
                                {'id': 4, 'attr':'ll oo he'},
                                {'id': 5, 'attr':'xy xx zz fg'},
-                               {'id': 6, 'attr':pd.np.NaN},
+                               {'id': 6, 'attr':np.NaN},
                                {'id': 7, 'attr':''}])
 
         self.B = pd.DataFrame([{'id': 1, 'attr':'zz fg xx'},
@@ -176,12 +177,12 @@ class FilterTablesTestCases(unittest.TestCase):
                           {'l_id': 2, 'l_attr':'200'},
                           {'l_id': 3, 'l_attr':'0'},
                           {'l_id': 4, 'l_attr':''},
-                          {'l_id': 5, 'l_attr':pd.np.NaN}])
+                          {'l_id': 5, 'l_attr':np.NaN}])
         B = pd.DataFrame([{'r_id': 1, 'r_attr':'200155'},
                           {'r_id': 2, 'r_attr':'190'},
                           {'r_id': 3, 'r_attr':'2010'},
                           {'r_id': 4, 'r_attr':''},
-                          {'r_id': 5, 'r_attr':pd.np.NaN},
+                          {'r_id': 5, 'r_attr':np.NaN},
                           {'r_id': 6, 'r_attr':'18950'}])
 
         qg2_tok = QgramTokenizer(2)
@@ -360,7 +361,7 @@ class FilterCandsetTestCases(unittest.TestCase):
                                {'l_id': 3, 'l_attr':'ab'},
                                {'l_id': 4, 'l_attr':'ll oo he'},
                                {'l_id': 5, 'l_attr':'xy xx zz fg'},
-                               {'l_id': 6, 'l_attr': pd.np.NaN}])
+                               {'l_id': 6, 'l_attr': np.NaN}])
 
         self.B = pd.DataFrame([{'r_id': 1, 'r_attr':'zz fg xx'},
                                {'r_id': 2, 'r_attr':'he ll'},

--- a/py_stringsimjoin/utils/converter.py
+++ b/py_stringsimjoin/utils/converter.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 
 def dataframe_column_to_str(dataframe, col_name, inplace=False, 
@@ -51,7 +52,7 @@ def dataframe_column_to_str(dataframe, col_name, inplace=False,
     if inplace:
         num_rows = len(dataframe[col_name])
         if (num_rows == 0 or sum(pd.isnull(dataframe[col_name])) == num_rows):
-            dataframe[col_name] = dataframe[col_name].astype(pd.np.object)
+            dataframe[col_name] = dataframe[col_name].astype(np.object)
             return True
         else:
             return series_to_str(dataframe[col_name], inplace)
@@ -91,18 +92,18 @@ def series_to_str(series, inplace=False):
     # Currently, we ignore the inplace flag when the series is empty and is of
     # type int or float. In this case, we will always return a copy.                       
     if len(series) == 0:                                                        
-        if col_type == pd.np.object and inplace:
+        if col_type == np.object and inplace:
             return True
         else:                                                                      
-            return series.astype(pd.np.object)    
+            return series.astype(np.object)    
 
-    if col_type == pd.np.object:
+    if col_type == np.object:
         # If column is already of type object, do not perform any conversion.
         if inplace:
             return True
         else:
             return series.copy()
-    elif pd.np.issubdtype(col_type, pd.np.integer):
+    elif np.issubdtype(col_type, np.integer):
         # If the column is of type int, then there are no missing values in the 
         # column and hence we can directly convert it to string using           
         # the astype method.     
@@ -112,7 +113,7 @@ def series_to_str(series, inplace=False):
             return True
         else:
             return col_str
-    elif pd.np.issubdtype(col_type, pd.np.float):
+    elif np.issubdtype(col_type, np.float):
         # If the column is of type float, then there are two cases:             
         # (1) column only contains interger values along with NaN.              
         # (2) column actually contains floating point values.                   
@@ -128,7 +129,7 @@ def series_to_str(series, inplace=False):
         # are NaN and will always return a copy of the column cast into 
         # object type.
         if len(col_non_nan_values) == 0:
-            return series.astype(pd.np.object)
+            return series.astype(np.object)
      
         # find how many of these values are actually integer values cast into   
         # float.
@@ -137,10 +138,10 @@ def series_to_str(series, inplace=False):
         # if all these values are interger values, then we handle according     
         # to case 1, else we proceed by case 2. 
         if int_values == len(col_non_nan_values):                               
-            col_str = series.apply(lambda val: pd.np.NaN if        
+            col_str = series.apply(lambda val: np.NaN if        
                                             pd.isnull(val) else str(int(val)))  
         else:                                                                   
-            col_str = series.apply(lambda val: pd.np.NaN if        
+            col_str = series.apply(lambda val: np.NaN if        
                                             pd.isnull(val) else str(val))
         if inplace:
             series.update(col_str)

--- a/py_stringsimjoin/utils/missing_value_handler.py
+++ b/py_stringsimjoin/utils/missing_value_handler.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pyprind
 
@@ -71,7 +72,7 @@ def get_pairs_with_missing_value(ltable, rtable,
                 output_row = [l_row[l_key_attr_index], r_row[r_key_attr_index]]
 
             if out_sim_score:
-                output_row.append(pd.np.NaN)
+                output_row.append(np.NaN)
 
             output_rows.append(output_row)
 

--- a/py_stringsimjoin/utils/missing_value_handler_disk.py
+++ b/py_stringsimjoin/utils/missing_value_handler_disk.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pyprind
 import os
@@ -89,7 +90,7 @@ def get_pairs_with_missing_value_disk(ltable, rtable,
                 record = [l_row[l_key_attr_index], r_row[r_key_attr_index]]
 
             if out_sim_score:
-                record.append(pd.np.NaN)
+                record.append(np.NaN)
 
             output_rows.append(record)
 

--- a/py_stringsimjoin/utils/validation.py
+++ b/py_stringsimjoin/utils/validation.py
@@ -1,6 +1,7 @@
 """Validation utilities"""
 
 import os
+import numpy as np
 import pandas as pd
 
 
@@ -27,7 +28,7 @@ def validate_attr(attr, table_cols, attr_label, table_label):
 
 def validate_attr_type(attr, attr_type, attr_label, table_label):
     """Check if the attribute is not of numeric type."""
-    if attr_type != pd.np.object:
+    if attr_type != np.object:
         raise AssertionError(attr_label + ' \'' + attr + '\' in ' + 
                              table_label + ' is not of string type.')
     return True


### PR DESCRIPTION
Similar to [this issue](https://github.com/anhaidgroup/py_entitymatching/issues/135), py_stringsimjoin contains deprecated usage of pandas.np. This PR replaces this usage with direct references to numpy.