### PR TITLE
Add CI for Python 3.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ matrix:
   - os: linux
     python: 3.8
     env: PYTHON_VERSION=3.8
+  - os: linux
+    python: 3.9
+    env: PYTHON_VERSION=3.9
   - os: osx
     language: generic
     env:
@@ -21,6 +24,10 @@ matrix:
     language: generic
     env:
     - PYTHON_VERSION=3.8
+  - os: osx
+    language: generic
+    env:
+    - PYTHON_VERSION=3.9
 
 compiler:
     - gcc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ environment:
     - python : 37-x64
     - python : 38
     - python : 38-x64
+    - python : 39
+    - python : 39-x64
 
 install:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
  
 Requirements
 ------------
-    * Python 2.7, 3.5, 3.6, 3.7, or 3.8
+    * Python 3.6, 3.7, 3.8, or 3.9
     * C++ compiler (parts of the package are in Cython for efficiency reasons, and you need C++ compiler to compile these parts) 
 
 Platforms
@@ -18,15 +18,12 @@ Dependencies
     * joblib (to write code that runs over multiple cores)
     * py_stringmatching (to tokenize and compute similarity scores between strings)
     * pyprind (to display progress bars)
-    * six (to ensure our code run on both Python 2.x and Python 3.x)
+    * six
 
 .. note::
 
      The py_stringsimjoin installer will automatically install the above required packages.
 
-.. note::
-
-     If using Python 2, py_stringsimjoin requires numpy less than 1.17; if using Python 3.5, numpy less than 1.19
 
 C Compiler Required
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -232,6 +232,7 @@ def setup_package():
                 'Programming Language :: Python :: 3.6',
                 'Programming Language :: Python :: 3.7',
                 'Programming Language :: Python :: 3.8',
+                'Programming Language :: Python :: 3.9',
                 'Topic :: Scientific/Engineering',
                 'Topic :: Utilities',
                 'Topic :: Software Development :: Libraries',


### PR DESCRIPTION
This PR adds Python 3.9 to the set of Python versions that `py-stringsimjoin` is tested against, updating the documentation accordingly.