### PR TITLE
fix: remove -march=native compile option for Darwin os

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 import os
+import platform
 import re
 import contextlib
 
@@ -36,9 +37,13 @@ from distutils.sysconfig import get_python_inc
 ## fix compiler and build options
 COMPILE_OPTIONS = {
         'msvc': ['/0x', '/EHsc'],
-        'mingw32': ['-O3', '-ffast-math', '-march=native'],
-        'other': ['-O3', '-ffast-math', '-march=native']
+        'mingw32': ['-O3', '-ffast-math'],
+        'other': ['-O3', '-ffast-math']
 }
+
+if platform.system() != 'Darwin':
+    COMPILE_OPTIONS['mingw32'].append('-march=native')
+    COMPILE_OPTIONS['other'].append('-march=native')
 
 LINK_OPTIONS = {
         'msvc': [],
@@ -74,26 +79,26 @@ def generate_cython():
 
 MODULES = {
         "py_stringsimjoin.index.inverted_index_cy": {'sources':["py_stringsimjoin/index/inverted_index_cy.pyx"],
-                                                        'comargs':[]            
-                                                        },  
+                                                        'comargs':[]
+                                                        },
         "py_stringsimjoin.index.position_index_cy": {'sources':["py_stringsimjoin/index/position_index_cy.pyx"],
-                                                        'comargs':[]            
-                                                        },  
+                                                        'comargs':[]
+                                                        },
         "py_stringsimjoin.similarity_measure.edit_distance": {'sources':["py_stringsimjoin/similarity_measure/edit_distance.pyx"],
                                                         'comargs':[]
                                                         },
 
         "py_stringsimjoin.similarity_measure.cosine": {'sources':["py_stringsimjoin/similarity_measure/cosine.pyx"],
-                                                        'comargs':[]            
-                                                        }, 
+                                                        'comargs':[]
+                                                        },
 
         "py_stringsimjoin.similarity_measure.dice": {'sources':["py_stringsimjoin/similarity_measure/dice.pyx"],
-                                                        'comargs':[]            
-                                                        }, 
+                                                        'comargs':[]
+                                                        },
 
         "py_stringsimjoin.similarity_measure.jaccard": {'sources':["py_stringsimjoin/similarity_measure/jaccard.pyx"],
-                                                        'comargs':[]            
-                                                        }, 
+                                                        'comargs':[]
+                                                        },
 
         "py_stringsimjoin.join.edit_distance_join_cy": {'sources':["py_stringsimjoin/join/edit_distance_join_cy.pyx",
                                                                    ],
@@ -116,22 +121,22 @@ MODULES = {
 
         "py_stringsimjoin.join.cosine_join_cy": {'sources':["py_stringsimjoin/join/cosine_join_cy.pyx"],
                                                         'comargs':["-I./py_stringsimjoin/index/"]
-                                                        },  
+                                                        },
 
         "py_stringsimjoin.join.dice_join_cy": {'sources':["py_stringsimjoin/join/dice_join_cy.pyx"],
                                                         'comargs':["-I./py_stringsimjoin/index/"]
-                                                        },  
+                                                        },
 
         "py_stringsimjoin.join.jaccard_join_cy": {'sources':["py_stringsimjoin/join/jaccard_join_cy.pyx"],
                                                         'comargs':["-I./py_stringsimjoin/index/"]
-                                                        },       
+                                                        },
 
         "py_stringsimjoin.join.set_sim_join_cy": {'sources':["py_stringsimjoin/join/set_sim_join_cy.pyx",
                                                              ],
                                                         'comargs':["-I./py_stringsimjoin/index/"]
-                                                        },   
+                                                        },
 
-        "py_stringsimjoin.utils.cython_utils": {'sources': ["py_stringsimjoin/utils/cython_utils.pyx", 
+        "py_stringsimjoin.utils.cython_utils": {'sources': ["py_stringsimjoin/utils/cython_utils.pyx",
                                                             ],
                                                'comargs': ["-I./py_stringsimjoin/index/"]
                                                }


### PR DESCRIPTION
This PR adds ability to install py_stringsimjoin through pip using mac with Darwin os