### PR TITLE
Fix bugs

### DIFF
--- a/py_stringsimjoin/__init__.py
+++ b/py_stringsimjoin/__init__.py
@@ -1,5 +1,5 @@
 
-__version__ = '0.3.2'
+__version__ = '0.3.3'
 
 # determine whether to use available cython implementations                     
 __use_cython__ = True 

--- a/py_stringsimjoin/utils/generic_helper.py
+++ b/py_stringsimjoin/utils/generic_helper.py
@@ -73,7 +73,7 @@ def convert_dataframe_to_list(table, join_attr_index,
 def convert_dataframe_to_array(dataframe, proj_attrs, join_attr, 
                                remove_nan=True):
     if remove_nan:
-        projected_dataframe = dataframe[proj_attrs].dropna(0, 
+        projected_dataframe = dataframe[proj_attrs].dropna(axis=0, 
                                                            subset=[join_attr])
     else:
         projected_dataframe = dataframe[proj_attrs]


### PR DESCRIPTION
Two small bug fixes:

1. I noticed when I was trying to check the version of the new py-stringsimjoin it kept saying 0.3.2 and finally found that the init file hadn't been updated to reflect the newer version.
2. I couldn't get the py-stringsimjoin to work with the new pandas version (2.1.1) and finally figured out that the issue is that newer versions of pandas requires that dataframe.dropna() uses keyword arguments only. I tested it locally and found once I change this in the generic_help.py file, it worked again for the file in notebooks/joining two tables using Jaccard measure.ipynb. 

I'm not sure if there are other compatibility issues with pandas>=2.0, but this at least satisfied the issues I was facing. 